### PR TITLE
feat: check api error and return nil if it's job does not exists

### DIFF
--- a/databricks/table_databricks_job_run.go
+++ b/databricks/table_databricks_job_run.go
@@ -2,6 +2,8 @@ package databricks
 
 import (
 	"context"
+        "fmt"
+        "strings"
 
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
@@ -210,6 +212,10 @@ func listJobRuns(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData
 	for {
 		response, err := client.Jobs.Impl().ListRuns(ctx, request)
 		if err != nil {
+                        if strings.Contains(err.Error(), fmt.Sprintf("Job %v does not exist", request.JobId)) {
+                                logger.Warn("databricks_job_run.listJobRuns", "api_error", err)
+                                return nil, nil
+                        }
 			logger.Error("databricks_job_run.listJobRuns", "api_error", err)
 			return nil, err
 		}


### PR DESCRIPTION
Related to issue: https://github.com/turbot/steampipe-plugin-databricks/issues/36

I add a check on error, if it contains `Job {JobId} does not exist`, we don't return an error but just `nil, nil`.
We can also do a strict comparison instead of using _contains_, but I think using _contains_ may be more stable with API evolution.

# Example query results
<details>
  <summary>Results</summary>
  

```
> select * from databricks.databricks_job_run where run_id = 42
+--------+----------+----------------+------------------+-------------------+----------+--------------------+--------+---------------+-------------------------+--------------+--------------+----------+----------------+------------+---------+----------->
| run_id | run_name | attempt_number | cleanup_duration | creator_user_name | end_time | execution_duration | job_id | number_in_job | original_attempt_run_id | run_duration | run_page_url | run_type | setup_duration | start_time | trigger | cluster_in>
+--------+----------+----------------+------------------+-------------------+----------+--------------------+--------+---------------+-------------------------+--------------+--------------+----------+----------------+------------+---------+----------->
+--------+----------+----------------+------------------+-------------------+----------+--------------------+--------+---------------+-------------------------+--------------+--------------+----------+----------------+------------+---------+----------->
```
</details>
